### PR TITLE
feat: integrate Swagger UI with externalized YAML specs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,17 +1,46 @@
 import os
-from flask import Flask
+from flask import Flask, redirect
 from flask_cors import CORS
 from .api.routes import api as schedule_bp
+from flasgger import Swagger
+
 
 def create_app():
     app = Flask(__name__)
 
-    env = os.environ.get("FLASK_ENV", "production")
-    if env == "development":
-        origins = "http://localhost:3000"
-    else:
-        origins = os.environ.get("FRONTEND_URL")
+    # Redirect root URL to Swagger UI
+    @app.route("/")
+    def root():
+        return redirect("/apidocs/")
 
+    # CORS setup
+    env = os.environ.get("FLASK_ENV", "production")
+    origins = "http://localhost:3000" if env == "development" else os.environ.get("FRONTEND_URL")
     CORS(app, resources={r"/api/*": {"origins": origins}})
+
+    # Swagger configuration
+    swagger_config = {
+        "headers": [],
+        "specs": [
+            {
+                "endpoint": "apispec",
+                "route":   "/apispec.json",
+                "rule_filter":   lambda rule: True,  # all endpoints
+                "model_filter":  lambda tag: True,   # all models
+            }
+        ],
+        "static_url_path": "/flasgger_static",
+        # Use a dropdown instead of raw URL input
+        "swagger_ui_config": {
+            "urls": [
+                { "url": "/apispec.json", "name": "Schedule API" }
+            ]
+        },
+        "swagger_ui":       True,
+        "specs_route":      "/apidocs/"
+    }
+    Swagger(app, config=swagger_config)
+
+    # Register API blueprint
     app.register_blueprint(schedule_bp, url_prefix="/api")
     return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Werkzeug==3.1.3
 gunicorn==20.1.0
 python-dotenv==1.0.0
 psutil==5.9.8
+flasgger==0.9.5


### PR DESCRIPTION
- Add Flasgger dependency and update `requirements.txt`
- Configure Swagger in `app/api/__init__.py`:
  - Redirect `/` to `/apidocs/`
  - Set up Swagger UI dropdown for “Schedule API”
  - Expose `/apispec.json` and serve UI at `/apidocs/`
- Refactor `routes.py`:
  - Remove inline YAML docstrings
  - Decorate `schedule()` with `@swag_from("schedule.yml")`
  - Preserve existing shift-allocation logic
- Create `app/api/schedule.yml`:
  - Define parameters, request/response schemas, and models (Shift, Employee, UnavailableDate, TimeFrame)
  - Include placeholder example payloads for `shifts` and `employees`
- Ensure Swagger UI is available in all environments and replaces raw URL input with a named dropdown