### PR TITLE
feat: expose Swagger UI and spec endpoints publicly via CORS

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,7 +16,13 @@ def create_app():
     # CORS setup
     env = os.environ.get("FLASK_ENV", "production")
     origins = "http://localhost:3000" if env == "development" else os.environ.get("FRONTEND_URL")
-    CORS(app, resources={r"/api/*": {"origins": origins}})
+    # CORS setup
+    CORS(app, resources={
+        r"/api/*": {"origins": origins},
+        r"/apidocs/*": {"origins": "*"},
+        r"/apispec.json": {"origins": "*"},
+        r"/flasgger_static/*": {"origins": "*"}
+    })
 
     # Swagger configuration
     swagger_config = {


### PR DESCRIPTION
- Extend CORS rules in `app/api/__init__.py` to allow all origins for:
  - `/apidocs/*`
  - `/apispec.json`
  - `/flasgger_static/*`
- Retain restricted CORS for `/api/*` based on `FRONTEND_URL` (or localhost in development)
- Keep root redirect (`/` → `/apidocs/`) and Swagger dropdown configuration intact