### PR TITLE
chore(docker): add and configure Docker container support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,62 @@
-# Python cache files
-__pycache__/
-*.py[cod]
-*$py.class
+# Byte-compiled / optimized / DLL files
 
-# Virtual environment directories
-venv/
-env/
-ENV/
+**pycache**/
+\*.py\[cod]
+\*\$py.class
 
-# OS-specific files
-.DS_Store
-Thumbs.db
+# C extensions
+
+\*.so
 
 # Distribution / packaging
+
+.Python
+env/
+venv/
 build/
+develop-eggs/
 dist/
-*.egg-info/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+\*.egg-info/
+.installed.cfg
+\*.egg
+
+# Virtual environments
+
+.venv/
+venv/
+
+# Flask instance folder
+
+instance/
+
+# Python-dotenv environment variables file
+
+.env
+.env.\*
 
 # Pytest cache
-.cache/
 
-# MyPy cache
-.mypy_cache/
+.pytest\_cache/
 
-# VS Code settings
+# Docker files
+
+dockerfile.save
+Dockerfile.save
+
+# Editor directories and files
+
 .vscode/
+.idea/
+\*.swp
 
-# Log files
-*.log
+# macOS
 
-# Local configuration files
-.env
+.DS\_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+### Use an official Python runtime as a parent image
+FROM python:3.10-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port Flask will run on
+EXPOSE 5000
+
+# Use gunicorn as WSGI server for production
+# 'app:app' corresponds to app.py exporting 'app'
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "wsgi:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 absl-py==2.1.0
 blinker==1.9.0
 click==8.1.7
-Flask==3.1.0
+Flask==2.2.5
 Flask-Cors==5.0.0
 immutabledict==4.2.1
 itsdangerous==2.2.0

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+# wsgi.py
+from app import create_app
+
+app = create_app()


### PR DESCRIPTION
- Add `Dockerfile` with Python 3.10-slim base, dependency install, and Gunicorn setup
- Create `wsgi.py` as the Gunicorn entrypoint for `CMD ["gunicorn", "-b", "0.0.0.0:5000", "wsgi:app"]`
- Remove legacy `Dockerfile.save` via `.gitignore` ;